### PR TITLE
Responsive History Page and Gallery Unification

### DIFF
--- a/historie.html
+++ b/historie.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset="UTF-8">
         <link rel="stylesheet" href="styl.css"/>
         <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
         <!-- <script defer src="galerie/galerie.js"></script> -->
@@ -7,7 +8,7 @@
         <script defer src="clanky/clanky.js"></script>
         <script defer src="js/frontInicializer.js"></script>
         <script defer src="js/galerie.js"></script>
-        <meta name="viewport" content="width=device-width", initial-scale="1">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
     </head>
     <body onload="initFront()">
         <div id="logo_block">
@@ -36,7 +37,7 @@
                 <img src="galerie/fotky/2025/2025_6.jpg" width="100%" id="myImg5" class="myImg">
 
             </div>
-            <div class="spacer" id="galery_link"><button class="galery_butt" id="clanky-2025" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2025" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2025" ><a href="vysledky/newvysledky.html?soubor=2025">Vysledky ↧</a></button></div>
+            <div class="spacer galery_link"><button class="galery_butt" id="clanky-2025" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2025" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2025" ><a href="vysledky/newvysledky.html?soubor=2025">Vysledky ↧</a></button></div>
             <div id="center">
                 <div id="2025place" class="clanky_place"></div>
             </div>
@@ -56,7 +57,7 @@
                 <img src="galerie/fotky/2024/2024_6.jpg" width="100%" id="myImg5" class="myImg">
 
             </div>
-            <div class="spacer" id="galery_link"><button class="galery_butt" id="clanky-2024" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2024" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2024" ><a href="vysledky/newvysledky.html?soubor=2024">Vysledky ↧</a></button></div>
+            <div class="spacer galery_link"><button class="galery_butt" id="clanky-2024" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2024" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2024" ><a href="vysledky/newvysledky.html?soubor=2024">Vysledky ↧</a></button></div>
             <div id="center">
                 <div id="2024place" class="clanky_place"></div>
             </div>
@@ -76,7 +77,7 @@
                 <img src="galerie/fotky/2023/2023_6.jpg" width="100%" id="myImg5" class="myImg">
 
             </div>
-            <div class="spacer" id="galery_link"><button class="galery_butt" id="clanky-2023" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2023" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2023" ><a href="vysledky/newvysledky.html?soubor=2023">Vysledky ↧</a></button></div>
+            <div class="spacer galery_link"><button class="galery_butt" id="clanky-2023" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2023" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2023" ><a href="vysledky/newvysledky.html?soubor=2023">Vysledky ↧</a></button></div>
             <div id="center">
                 <div id="2023place" class="clanky_place"></div>
             </div>
@@ -96,7 +97,7 @@
                 <img src="galerie/fotky/2022/2022_6.jpg" width="100%" id="myImg5" class="myImg">
 
             </div>
-            <div class="spacer" id="galery_link"><button class="galery_butt" id="clanky-2022" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2022" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2022" onclick="down_vysledky(this)"><a href="vysledky.html">Vysledky ↧</a></button></div>
+            <div class="spacer galery_link"><button class="galery_butt" id="clanky-2022" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2022" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2022" onclick="down_vysledky(this)"><a href="vysledky.html">Vysledky ↧</a></button></div>
             <div id="center">
                 <div id="2022place" class="clanky_place"></div>
             </div>
@@ -116,7 +117,7 @@
                 <img src="galerie/fotky/2021/2021_6.jpg" width="100%" id="myImg5" class="myImg">
 
             </div>
-            <div class="spacer" id="galery_link"><button class="galery_butt" id="clanky-2021" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2021" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2021" onclick="down_vysledky(this)">Vysledky ↧</button></div>
+            <div class="spacer galery_link"><button class="galery_butt" id="clanky-2021" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2021" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2021" onclick="down_vysledky(this)">Vysledky ↧</button></div>
             <div id="center">
                 <div id="2021place" class="clanky_place"></div>
             </div>
@@ -133,7 +134,7 @@
                 <img src="galerie/fotky/2020/2020_5.jpg" width="100%" id="myImg4" class="myImg" >
                 <img src="galerie/fotky/2020/2020_6.jpg" width="100%" id="myImg5" class="myImg" >
             </div>
-            <div class="spacer" id="galery_link"><button class="galery_butt" id="clanky-2020" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2020" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2020" onclick="down_vysledky(this)">Vysledky ↧</button></div>
+            <div class="spacer galery_link"><button class="galery_butt" id="clanky-2020" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2020" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2020" onclick="down_vysledky(this)">Vysledky ↧</button></div>
             <div id="center">
                 <div id="2020place" class="clanky_place"></div>
             </div>
@@ -150,7 +151,7 @@
                 <img src="galerie/fotky/2019/2019_5.jpg" width="100%" id="myImg4" class="myImg" >
                 <img src="galerie/fotky/2019/2019_6.jpg" width="100%" id="myImg5" class="myImg" >
             </div>
-            <div class="spacer" id="galery_link"><button class="galery_butt" id="clanky-2019" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2019" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2019" onclick="down_vysledky(this)">Vysledky ↧</button></div>
+            <div class="spacer galery_link"><button class="galery_butt" id="clanky-2019" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2019" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2019" onclick="down_vysledky(this)">Vysledky ↧</button></div>
             <div id="center">
                 <div id="2019place" class="clanky_place"></div>
             </div>
@@ -167,7 +168,7 @@
                 <img src="galerie/fotky/2018/2018_5.jpg" width="100%" id="myImg4" class="myImg" >
                 <img src="galerie/fotky/2018/2018_6.jpg" width="100%" id="myImg5" class="myImg" >
             </div>
-                <div class="spacer" id="galery_link"><button class="galery_butt" id="clanky-2018" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2018" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2018" onclick="down_vysledky(this)">Vysledky ↧</button></div>
+                <div class="spacer galery_link"><button class="galery_butt" id="clanky-2018" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2018" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2018" onclick="down_vysledky(this)">Vysledky ↧</button></div>
                 <div id="center">
                     <div id="2018place" class="clanky_place"></div>
             </div>
@@ -184,7 +185,7 @@
                 <img src="galerie/fotky/2017/2017_5.jpg" width="100%" id="myImg4" class="myImg" >
                 <img src="galerie/fotky/2017/2017_6.jpg" width="100%" id="myImg5" class="myImg" >
             </div>
-             <div class="spacer" id="galery_link"><button class="galery_butt" id="clanky-2017" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2017" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2017" onclick="down_vysledky(this)">Vysledky ↧</button></div>
+             <div class="spacer galery_link"><button class="galery_butt" id="clanky-2017" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2017" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2017" onclick="down_vysledky(this)">Vysledky ↧</button></div>
                 <div id="center">
                     <div id="2017place" class="clanky_place"></div>
             </div>
@@ -201,7 +202,7 @@
                 <img src="galerie/fotky/2016/2016_5.jpg" width="100%" id="myImg4" class="myImg" >
                 <img src="galerie/fotky/2016/2016_6.jpg" width="100%" id="myImg5" class="myImg" >
             </div>
-            <div class="spacer" id="galery_link"><button class="galery_butt" id="clanky-2016" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2016" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2016" onclick="down_vysledky(this)">Vysledky ↧</button></div>
+            <div class="spacer galery_link"><button class="galery_butt" id="clanky-2016" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2016" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2016" onclick="down_vysledky(this)">Vysledky ↧</button></div>
                 <div id="center">
                     <div id="2016place" class="clanky_place"></div>
             </div>
@@ -218,7 +219,7 @@
                 <img src="galerie/fotky/2015/2015_5.jpg" width="100%" id="myImg4" class="myImg">
                 <img src="galerie/fotky/2015/2015_6.jpg" width="100%" id="myImg5" class="myImg">
             </div>
-            <div class="spacer" id="galery_link"><button class="galery_butt" id="clanky-2015" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2015" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2015" onclick="down_vysledky(this)">Vysledky ↧</button></div>
+            <div class="spacer galery_link"><button class="galery_butt" id="clanky-2015" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2015" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2015" onclick="down_vysledky(this)">Vysledky ↧</button></div>
                 <div id="center">
                     <div id="2015place" class="clanky_place"></div>
             </div>
@@ -235,7 +236,7 @@
                 <img src="galerie/fotky/2014/2014_5.jpg" width="100%" id="myImg4" class="myImg">
                 <img src="galerie/fotky/2014/2014_6.jpg" width="100%" id="myImg5" class="myImg">
             </div>
-            <div class="spacer" id="galery_link"><button class="galery_butt" id="clanky-2014" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2014" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2014" onclick="down_vysledky(this)">Vysledky ↧</button></div>
+            <div class="spacer galery_link"><button class="galery_butt" id="clanky-2014" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2014" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2014" onclick="down_vysledky(this)">Vysledky ↧</button></div>
                 <div id="center">
                     <div id="2014place" class="clanky_place"></div>
             </div>
@@ -252,7 +253,7 @@
                 <img src="galerie/fotky/2013/2013_5.jpg" width="100%" id="myImg4" class="myImg">
                 <img src="galerie/fotky/2013/2013_6.jpg" width="100%" id="myImg5" class="myImg">
             </div>
-            <div class="spacer" id="galery_link"><button class="galery_butt" id="clanky-2013" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2013" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2013" onclick="down_vysledky(this)">Vysledky ↧</button></div>
+            <div class="spacer galery_link"><button class="galery_butt" id="clanky-2013" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2013" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2013" onclick="down_vysledky(this)">Vysledky ↧</button></div>
                 <div id="center">
                     <div id="2013place" class="clanky_place"></div>
             </div>
@@ -269,7 +270,7 @@
                 <img src="galerie/fotky/2012/2012_5.jpg" width="100%" id="myImg4" class="myImg">
                 <img src="galerie/fotky/2012/2012_6.jpg" width="100%" id="myImg5" class="myImg">
             </div>
-            <div class="spacer" id="galery_link"><button class="galery_butt" id="clanky-2012" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2012" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2012" onclick="down_vysledky(this)">Vysledky ↧</button></div>
+            <div class="spacer galery_link"><button class="galery_butt" id="clanky-2012" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2012" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2012" onclick="down_vysledky(this)">Vysledky ↧</button></div>
                 <div id="center">
                     <div id="2012place" class="clanky_place"></div>
             </div>
@@ -286,205 +287,9 @@
                 <img src="galerie/fotky/2011/2011_5.jpg" width="100%" id="myImg4" class="myImg">
                 <img src="galerie/fotky/2011/2011_6.jpg" width="100%" id="myImg5" class="myImg">
             </div>
-            <div class="spacer" id="galery_link"><button class="galery_butt" id="clanky-2011" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2011" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2011" onclick="down_vysledky(this)">Vysledky ↧</button></div>
+            <div class="spacer galery_link"><button class="galery_butt" id="clanky-2011" onclick="down_clanky(this)">Članky ↧</button><button class="galery_butt" id="galerie-2011" onclick="down_galerie(this)">Galerie ↧</button><button class="galery_butt" id="vysledky-2011" onclick="down_vysledky(this)">Vysledky ↧</button></div>
                 <div id="center">
                     <div id="2011place" class="clanky_place"></div>
-            </div>
-        </div>
-    </div>
-    <div id="mobil_galerie">
-        <div id="2024" class="fotky_frame_m">
-            <h3>2024</h3><br>
-            <div class="top_galery_m">
-                <div class="main_left_m"><img src="galerie/fotky/2024/2024_1.jpg" width="100%" id="myImg0" class="myImg"></div>
-                <div class="main_right_m"><img src="galerie/fotky/2024/2024_2.jpg" width="100%" id="myImg1"class="myImg" ></div>
-            </div>
-            <div class="bottom_galery_m">
-
-                <img src="galerie/fotky/2024/2024_3.jpg" width="100%" id="myImg2" class="myImg">
-                <img src="galerie/fotky/2024/2024_4.jpg" width="100%" id="myImg3" class="myImg">
-                
-                <img src="galerie/fotky/2024/2024_5.jpg" width="100%" id="myImg4" class="myImg">
-                <img src="galerie/fotky/2024/2024_6.jpg" width="100%" id="myImg5" class="myImg">
-
-            </div>
-        <div id="2023" class="fotky_frame_m">
-            <h3>2023</h3><br>
-            <div class="top_galery_m">
-                <div class="main_left_m"><img src="galerie/fotky/2023/2023_1.jpg" width="100%" id="myImg0" class="myImg"></div>
-                <div class="main_right_m"><img src="galerie/fotky/2023/2023_2.jpg" width="100%" id="myImg1"class="myImg" ></div>
-            </div>
-            <div class="bottom_galery_m">
-
-                <img src="galerie/fotky/2023/2023_3.jpg" width="100%" id="myImg2" class="myImg">
-                <img src="galerie/fotky/2023/2023_4.jpg" width="100%" id="myImg3" class="myImg">
-                
-                <img src="galerie/fotky/2023/2023_5.jpg" width="100%" id="myImg4" class="myImg">
-                <img src="galerie/fotky/2023/2023_6.jpg" width="100%" id="myImg5" class="myImg">
-
-            </div>
-    </div>
-    <div id="2022" class="fotky_frame_m">
-            <h3>2022</h3><br>
-            <div class="top_galery_m">
-                <div class="main_left_m"><img src="galerie/fotky/2022/2022_1.jpg" width="100%" id="myImg0" class="myImg"></div>
-                <div class="main_right_m"><img src="galerie/fotky/2022/2022_2.jpg" width="100%" id="myImg1"class="myImg" ></div>
-            </div>
-            <div class="bottom_galery_m">
-
-                <img src="galerie/fotky/2022/2022_3.jpg" width="100%" id="myImg2" class="myImg">
-                <img src="galerie/fotky/2022/2022_4.jpg" width="100%" id="myImg3" class="myImg">
-                
-                <img src="galerie/fotky/2022/2022_5.jpg" width="100%" id="myImg4" class="myImg">
-                <img src="galerie/fotky/2022/2022_6.jpg" width="100%" id="myImg5" class="myImg">
-
-            </div>
-    </div>
-        <div id="2021" class="fotky_frame_m">
-        
-            <h3>2021</h3><br>
-            <div class="top_galery_m">
-                <div class="main_left_m"><img src="galerie/fotky/2021/2021_1.jpg" width="100%" id="myImg0" class="myImg"></div>
-                <div class="main_right_m"><img src="galerie/fotky/2021/2021_2.png" width="100%" id="myImg1"class="myImg" ></div>
-            </div>
-            <div class="bottom_galery_m">
- 
-                <img src="galerie/fotky/2021/2021_3.jpg" width="100%" id="myImg2" class="myImg">
-                <img src="galerie/fotky/2021/2021_4.jpg" width="100%" id="myImg3" class="myImg">
- 
-                <img src="galerie/fotky/2021/2021_5.jpg" width="100%" id="myImg4" class="myImg">
-                <img src="galerie/fotky/2021/2021_6.jpg" width="100%" id="myImg5" class="myImg">
- 
-            </div>
-        </div>
-        <div id="2020" class="fotky_frame_m">
-            <h3>2020</h3><br>
-            <div class="top_galery_m">
-                <div class="main_left_m"><img src="galerie/fotky/2020/2020_1.jpg" width="100%" id="myImg0" class="myImg" loading="lazy"></div>
-                <div class="main_right_m"><img src="galerie/fotky/2020/2020_2.jpg" width="100%" id="myImg1"class="myImg" loading="lazy"></div>
-            </div>
-            <div class="bottom_galery_m">
-                <img src="galerie/fotky/2020/2020_3.jpg" width="100%" id="myImg2" class="myImg" loading="lazy">
-                <img src="galerie/fotky/2020/2020_4.jpg" width="100%" id="myImg3" class="myImg" loading="lazy">
-                <img src="galerie/fotky/2020/2020_5.jpg" width="100%" id="myImg4" class="myImg" loading="lazy">
-                <img src="galerie/fotky/2020/2020_6.jpg" width="100%" id="myImg5" class="myImg" loading="lazy">
-            </div>
-        </div>
-        <div id="2019" class="fotky_frame_m">
-            <h3>2019</h3><br>
-            <div class="top_galery_m">
-                <div class="main_left_m"><img src="galerie/fotky/2019/2019_1.jpg" width="100%" id="myImg0" class="myImg" loading="lazy"></div>
-                <div class="main_right_m"><img src="galerie/fotky/2019/2019_2.jpg" width="100%" id="myImg1"class="myImg" loading="lazy"></div>
-            </div>
-            <div class="bottom_galery_m">
-                <img src="galerie/fotky/2019/2019_3.jpg" width="100%" id="myImg2" class="myImg" loading="lazy">
-                <img src="galerie/fotky/2019/2019_4.jpg" width="100%" id="myImg3" class="myImg" loading="lazy">
-                <img src="galerie/fotky/2019/2019_5.jpg" width="100%" id="myImg4" class="myImg" loading="lazy">
-                <img src="galerie/fotky/2019/2019_6.jpg" width="100%" id="myImg5" class="myImg" loading="lazy">
-            </div>
-        </div>
-        <div id="2018" class="fotky_frame_m">
-            <h3>2018</h3><br>
-            <div class="top_galery_m">
-                <div class="main_left_m"><img src="galerie/fotky/2018/2018_1.jpg" width="100%" id="myImg0" class="myImg" loading="lazy"></div>
-                <div class="main_right_m"><img src="galerie/fotky/2018/2018_2.jpg" width="100%" id="myImg1"class="myImg" loading="lazy" ></div>
-            </div>
-            <div class="bottom_galery_m">
-                <img src="galerie/fotky/2018/2018_3.jpg" width="100%" id="myImg2" class="myImg" loading="lazy">
-                <img src="galerie/fotky/2018/2018_4.jpg" width="100%" id="myImg3" class="myImg" loading="lazy">
-                <img src="galerie/fotky/2018/2018_5.jpg" width="100%" id="myImg4" class="myImg" loading="lazy">
-                <img src="galerie/fotky/2018/2018_6.jpg" width="100%" id="myImg5" class="myImg" loading="lazy">
-            </div>
-        </div>
-        <div id="2017" class="fotky_frame_m">
-            <h3>2017</h3><br>
-            <div class="top_galery_m">
-                <div class="main_left_m"><img src="galerie/fotky/2017/2017_1.jpg" width="100%" id="myImg0" class="myImg" loading="lazy"></div>
-                <div class="main_right_m"><img src="galerie/fotky/2017/2017_2.jpg" width="100%" id="myImg1"class="myImg" loading="lazy" ></div>
-            </div>
-            <div class="bottom_galery_m">
-                <img src="galerie/fotky/2017/2017_3.jpg" width="100%" id="myImg2" class="myImg" loading="lazy">
-                <img src="galerie/fotky/2017/2017_4.jpg" width="100%" id="myImg3" class="myImg" loading="lazy">
-                <img src="galerie/fotky/2017/2017_5.jpg" width="100%" id="myImg4" class="myImg" loading="lazy">
-                <img src="galerie/fotky/2017/2017_6.jpg" width="100%" id="myImg5" class="myImg" loading="lazy">
-            </div>
-        </div>
-        <div id="2016" class="fotky_frame_m">
-            <h3>2016</h3><br>
-            <div class="top_galery_m">
-                <div class="main_left_m"><img src="galerie/fotky/2016/2016_1.jpg" width="100%" id="myImg0" class="myImg" loading="lazy"></div>
-                <div class="main_right_m"><img src="galerie/fotky/2016/2016_2.jpg" width="100%" id="myImg1"class="myImg" loading="lazy" ></div>
-            </div>
-            <div class="bottom_galery_m">
-                <img src="galerie/fotky/2016/2016_3.jpg" width="100%" id="myImg2" class="myImg" loading="lazy">
-                <img src="galerie/fotky/2016/2016_4.jpg" width="100%" id="myImg3" class="myImg" loading="lazy">
-                <img src="galerie/fotky/2016/2016_5.jpg" width="100%" id="myImg4" class="myImg" loading="lazy">
-                <img src="galerie/fotky/2016/2016_6.jpg" width="100%" id="myImg5" class="myImg" loading="lazy">
-            </div>
-        </div>
-        <div id="2015" class="fotky_frame_m">
-            <h3>2015</h3><br>
-            <div class="top_galery_m">
-                <div class="main_left_m"><img src="galerie/fotky/2015/2015_1.jpg" width="100%" id="myImg0" class="myImg"></div>
-                <div class="main_right_m"><img src="galerie/fotky/2015/2015_2.jpg" width="100%" id="myImg1"class="myImg" ></div>
-            </div>
-            <div class="bottom_galery_m">
-                <img src="galerie/fotky/2015/2015_3.jpg" width="100%" id="myImg2" class="myImg">
-                <img src="galerie/fotky/2015/2015_4.jpg" width="100%" id="myImg3" class="myImg">
-                <img src="galerie/fotky/2015/2015_5.jpg" width="100%" id="myImg4" class="myImg">
-                <img src="galerie/fotky/2015/2015_6.jpg" width="100%" id="myImg5" class="myImg">
-            </div>
-        </div>
-        <div id="2014" class="fotky_frame_m">
-            <h3>2014</h3><br>
-            <div class="top_galery_m">
-                <div class="main_left_m"><img src="galerie/fotky/2014/2014_1.jpg" width="100%" id="myImg0" class="myImg"></div>
-                <div class="main_right_m"><img src="galerie/fotky/2014/2014_2.jpg" width="100%" id="myImg1"class="myImg" ></div>
-            </div>
-            <div class="bottom_galery_m">
-                <img src="galerie/fotky/2014/2014_3.jpg" width="100%" id="myImg2" class="myImg">
-                <img src="galerie/fotky/2014/2014_4.jpg" width="100%" id="myImg3" class="myImg">
-                <img src="galerie/fotky/2014/2014_5.jpg" width="100%" id="myImg4" class="myImg">
-                <img src="galerie/fotky/2014/2014_6.jpg" width="100%" id="myImg5" class="myImg">
-            </div>
-        </div>
-        <div id="2013" class="fotky_frame_m">
-            <h3>2013</h3><br>
-            <div class="top_galery_m">
-                <div class="main_left_m"><img src="galerie/fotky/2013/2013_1.jpg" width="100%" id="myImg0" class="myImg"></div>
-                <div class="main_right_m"><img src="galerie/fotky/2013/2013_2.jpg" width="100%" id="myImg1"class="myImg" ></div>
-            </div>
-            <div class="bottom_galery_m">
-                <img src="galerie/fotky/2013/2013_3.jpg" width="100%" id="myImg2" class="myImg">
-                <img src="galerie/fotky/2013/2013_4.jpg" width="100%" id="myImg3" class="myImg">
-                <img src="galerie/fotky/2013/2013_5.jpg" width="100%" id="myImg4" class="myImg">
-                <img src="galerie/fotky/2013/2013_6.jpg" width="100%" id="myImg5" class="myImg">
-            </div>
-        </div>
-        <div id="2012" class="fotky_frame_m">
-            <h3>2012</h3><br>
-            <div class="top_galery_m">
-                <div class="main_left_m"><img src="galerie/fotky/2012/2012_1.jpg" width="100%" id="myImg0" class="myImg"></div>
-                <div class="main_right_m"><img src="galerie/fotky/2012/2012_2.jpg" width="100%" id="myImg1"class="myImg" ></div>
-            </div>
-            <div class="bottom_galery_m">
-                <img src="galerie/fotky/2012/2012_3.jpg" width="100%" id="myImg2" class="myImg">
-                <img src="galerie/fotky/2012/2012_4.jpg" width="100%" id="myImg3" class="myImg">
-                <img src="galerie/fotky/2012/2012_5.jpg" width="100%" id="myImg4" class="myImg">
-                <img src="galerie/fotky/2012/2012_6.jpg" width="100%" id="myImg5" class="myImg">
-            </div>
-        </div>
-        <div id="2011" class="fotky_frame_m">
-            <h3>2011</h3><br>
-            <div class="top_galery_m">
-                <div class="main_left_m"><img src="galerie/fotky/2011/2011_1.jpg" width="100%" id="myImg0" class="myImg"></div>
-                <div class="main_right_m"><img src="galerie/fotky/2011/2011_2.jpg" width="100%" id="myImg1"class="myImg" ></div>
-            </div>
-            <div class="bottom_galery_m">
-                <img src="galerie/fotky/2011/2011_3.jpg" width="100%" id="myImg2" class="myImg">
-                <img src="galerie/fotky/2011/2011_4.jpg" width="100%" id="myImg3" class="myImg">
-                <img src="galerie/fotky/2011/2011_5.jpg" width="100%" id="myImg4" class="myImg">
-                <img src="galerie/fotky/2011/2011_6.jpg" width="100%" id="myImg5" class="myImg">
             </div>
         </div>
     </div>

--- a/styl.css
+++ b/styl.css
@@ -278,13 +278,6 @@ menu{
   #propozice{
     display: none;
   }
-  #mobil_galerie{
-    display: block;
-  }
-  #pc_galerie{
-    display: none;
-  }
-
 }
 #odeslat{
   color:white;
@@ -511,7 +504,7 @@ menu{
   border-color: #303b4a;
   
 }
-#galery_link
+.galery_link
 {
   margin-top: 1%;
 }
@@ -611,16 +604,28 @@ menu{
   }
 
   .bottom_galery{
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr 1fr !important;
     padding-bottom: 2%;
-    }
+  }
 
   .top_galery{
-      display: grid;
-      grid-template-rows: 1fr 1fr;
-      gap:10%;
-      padding-bottom: 2%;
-      }
+    grid-template-columns: 1fr !important;
+    grid-template-rows: auto auto;
+    gap: 2%;
+    padding-bottom: 2%;
+  }
+
+  .galery_link {
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .galery_butt, .galery_butt_reversed {
+    width: 80% !important;
+    padding: 15px !important;
+    font-size: 1.1em;
+  }
 }
 
 @media screen and (max-width: 400px) {
@@ -629,20 +634,6 @@ menu{
   }
 }
 
-.fotky_frame_m{
-  border-radius: 5px;
-padding:1%;
-margin-left: 10%;
-margin-right: 10%;
-margin-top: 1%;
-margin-bottom: 1%;
-text-align: center;
-background-color: #dadfe4;
- 
-}
-.fotky_frame_m h3{
-  color: #303b4a;
-}
 
 .fotky_frame{
   border-radius: 5px;
@@ -659,21 +650,6 @@ background-color: #dadfe4;
   color: #303b4a;
 }
 
-.top_galery_m{
-  display: grid;
-  grid-template-rows: 1fr 1fr;
-  gap:2%;
-  padding-bottom: 2%;
-  }
-  
-.bottom_galery_m{
-  padding-top: 2%;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
-  gap:2%;
-  padding-bottom: 1%;
-  }
 
   .top_galery{
     display: grid;


### PR DESCRIPTION
I have simplified the 'Historie' page as requested. 

Changes include:
1. **Removed Redundancy:** Deleted the separate mobile gallery version (`#mobil_galerie`), leaving only the main gallery structure.
2. **Responsive Design:** Updated the CSS to automatically adapt the layout for mobile devices. On screens smaller than 800px, the images now stack vertically or in a 2-column grid instead of the original 4-column layout.
3. **Improved Accessibility:** Enlarged the navigation buttons on mobile to make them easier to tap.
4. **Encoding Fix:** Added UTF-8 support to ensure Czech characters (like in 'Portské') are displayed correctly.
5. **HTML Clean-up:** Fixed invalid duplicate IDs and a broken viewport meta tag.

I verified these changes by testing both mobile (375px) and desktop (1280px) views.

---
*PR created automatically by Jules for task [4080901769121726437](https://jules.google.com/task/4080901769121726437) started by @Thechopsee*