### PR TITLE
Migrate history page to web_new

### DIFF
--- a/web_new/dev_server.log
+++ b/web_new/dev_server.log
@@ -1,0 +1,10 @@
+
+> web_new@0.0.1 dev
+> vite dev
+
+5:40:57 AM [vite] (client) Forced re-optimization of dependencies
+
+  VITE v8.0.8  ready in 1301 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose

--- a/web_new/src/lib/components/Navbar.svelte
+++ b/web_new/src/lib/components/Navbar.svelte
@@ -13,7 +13,7 @@
 	<nav id="menu_web">
 		<a href="/" class:active={page.url.pathname === '/'}>Těrlická plachta 2026</a>
 		<span class="sep">|</span>
-		<a href="/historie.html">Historie</a>
+		<a href="/historie" class:active={page.url.pathname.startsWith('/historie')}>Historie</a>
 		<span class="sep">|</span>
 		<a href="/registrace" class:active={page.url.pathname === '/registrace'}>Registrace</a>
 		<span class="sep">|</span>
@@ -21,7 +21,7 @@
 	</nav>
 	<nav id="menu_mob">
 		<a href="/" class:active={page.url.pathname === '/'}>Těrlická plachta 2026</a>
-		<a href="/historie.html">Historie</a>
+		<a href="/historie" class:active={page.url.pathname.startsWith('/historie')}>Historie</a>
 		<a href="/registrace" class:active={page.url.pathname === '/registrace'}>Registrace</a>
 		<a href="/kontakty.html">Kontakt</a>
 	</nav>

--- a/web_new/src/lib/data/history.js
+++ b/web_new/src/lib/data/history.js
@@ -1,0 +1,287 @@
+export const historyData = [
+	{
+		year: 2025,
+		results: { type: 'new', url: '/vysledky/newvysledky.html?soubor=2025' },
+		articles: [
+			{ label: 'Minisail.cz', url: 'https://www.minisail.cz/setkani/z-akci/id:20506/terlicko-2025' }
+		],
+		gallery: [
+			{
+				label: 'Drive-Val',
+				url: 'https://drive.google.com/drive/folders/1klacGCjAQwaq7JacOwutu30z0ZV3lZxG?usp=sharing'
+			},
+			{ label: 'Rajče-ferodedek', url: 'https://www.rajce.idnes.cz/album/3UDJRRvi7ibZymXC?' },
+			{ label: 'Zonerama-Jiří Muclinger', url: 'https://eu.zonerama.com/6twua/Album/13927684' }
+		]
+	},
+	{
+		year: 2024,
+		results: { type: 'new', url: '/vysledky/newvysledky.html?soubor=2024' },
+		articles: [
+			{
+				label: 'Minisail.cz',
+				url: 'https://www.minisail.cz/setkani/z-akci/id:18787/terlicka-plachta-2024'
+			},
+			{
+				label: 'Polar',
+				url: 'https://polar.cz/index.php/zpravy/moravskoslezsky-kraj/cely-ms-kraj/11000045241/lodni-modelari-soutezili-na-prehrade-v-zavode-terlicka-plachta'
+			}
+		],
+		gallery: [
+			{ label: 'Youtube-Jiří Muclinger', url: 'https://youtu.be/CM5oRtg5olM?feature=shared' },
+			{
+				label: 'Video-Polar',
+				url: 'https://polar.cz/index.php/zpravy/moravskoslezsky-kraj/cely-ms-kraj/11000045241/lodni-modelari-soutezili-na-prehrade-v-zavode-terlicka-plachta'
+			},
+			{ label: 'Rajce-ferodedek', url: 'https://www.rajce.idnes.cz/album/JiJysRZxaYkpVTrx?' },
+			{
+				label: 'Video-Petr Staněk',
+				url: 'https://www.facebook.com/61558716742289/videos/1052083829681200/'
+			},
+			{
+				label: 'Drive-Val',
+				url: 'https://drive.google.com/drive/folders/1Og-qtfF3meH31QkNbqLy815w8R8B1yld?usp=sharing'
+			}
+		]
+	},
+	{
+		year: 2023,
+		results: { type: 'new', url: '/vysledky/newvysledky.html?soubor=2023' },
+		articles: [
+			{
+				label: 'Minisail.cz',
+				url: 'https://www.minisail.cz/setkani/z-akci/id:17319/terlicka-plachta-2023'
+			}
+		],
+		gallery: [
+			{
+				label: 'Drive-Val',
+				url: 'https://drive.google.com/drive/folders/1wGup31O7Z-RAbWfALy5O8KVlaVV7sUGE?usp=drive_link'
+			},
+			{ label: 'Video-seb', url: 'https://youtu.be/zMv-NKWecbU?feature=shared' }
+		]
+	},
+	{
+		year: 2022,
+		results: { type: 'link', url: '/vysledky.html' },
+		articles: [
+			{
+				label: 'Minisail.cz',
+				url: 'https://www.minisail.cz/setkani/z-akci/id:15629/terlicka-plachta-2022'
+			},
+			{ label: 'Oficiální report', url: '/clanky/Rep2022.pdf' }
+		],
+		gallery: [
+			{
+				label: 'Rajce-Ferodedek',
+				url: 'https://minisail.rajce.idnes.cz/12._Terlicka_plachta_30._09._-_02._10._22/?'
+			},
+			{
+				label: 'Drive-Val',
+				url: 'https://drive.google.com/drive/folders/1VSYOAUbJJYjVkutYKk-_xaeN9fKaUsuQ?usp=sharing'
+			},
+			{
+				label: 'Drive-JiříJakubec',
+				url: 'https://drive.google.com/drive/folders/1ADp1lblpfIwnLGYfA-xfqVesONJfR5cg?usp=share_link'
+			}
+		]
+	},
+	{
+		year: 2021,
+		results: { type: 'download' },
+		articles: [
+			{
+				label: 'Polar',
+				url: 'https://polar.cz/zpravy/karvinsko/terlicko/11000027836/na-terlicke-plachte-zasahovali-potapeci?fbclid=IwAR2vnLrZcUTEOr5Ky3UY4bTVhog1Ef7xCsAeJpKNKf3HQvPQex_TubySk8U'
+			},
+			{ label: 'Minisail.cz', url: 'https://www.minisail.cz/setkani/z-akci/id:13859' },
+			{ label: 'Oficiální report', url: '/clanky/tp2021.pdf' },
+			{ label: 'Těrlický miniexpress', url: 'https://www.youtube.com/watch?v=llcK838mBz0' }
+		],
+		gallery: [
+			{
+				label: 'Minisail.pl',
+				url: 'http://www.minisail.pl/index.php/2021/10/06/terlicko-2021/?fbclid=IwAR34HRgYVQOMhwWfLUEv8cdUjZQgTdGfFcr2uejdDD8dvlsD7uwIIFKEILU'
+			},
+			{
+				label: 'Rajce-Ferodedek',
+				url: 'https://minisail.rajce.idnes.cz/Terlicka_plachta_1._-_3._10._2021/'
+			},
+			{
+				label: 'Drive-Val',
+				url: 'https://drive.google.com/drive/folders/1JG2F9iNUn6NOawPQnZOkL0AGFgLFxVpd?usp=sharing'
+			},
+			{
+				label: 'Fotky Google-Snek',
+				url: 'https://photos.google.com/share/AF1QipNnHDr13oX2xww9A2vgowscje3L-Q2GszbPmqOWp4COteTuuM1zFRxtRB-rCBN-Cw?key=VE9GN1dhQmd6VjdxTHoyd19wRWdxVE1MMHY1TE93'
+			},
+			{ label: 'Rajce-Kubik-team', url: 'https://kubik-team.rajce.idnes.cz/Terlicka_plachta_2021/' }
+		]
+	},
+	{
+		year: 2020,
+		results: { type: 'download' },
+		articles: [
+			{
+				label: 'minisail.cz',
+				url: 'https://www.minisail.cz/setkani/z-akci/id:12507/x-terlicka-plachta-2020'
+			}
+		],
+		gallery: [
+			{
+				label: 'Drive-Val',
+				url: 'https://drive.google.com/drive/folders/1zKT3x748ADWmIbU-sOcDF5jGU6uX26-1?usp=sharing'
+			},
+			{ label: 'Rajce-Kubik-team', url: 'https://kubik-team.rajce.idnes.cz/Terlicka_plachta_2020/' },
+			{ label: 'Rajce-daja-se', url: 'https://daja-se.rajce.idnes.cz/Terlicka_plachta_2020/' },
+			{
+				label: 'Rajce-Ferodedek',
+				url: 'https://minisail.rajce.idnes.cz/Jubilejni_X._Terlicka_plachta_25._-27._09._2020/'
+			}
+		]
+	},
+	{
+		year: 2019,
+		results: { type: 'download' },
+		articles: [
+			{
+				label: 'minisail.cz',
+				url: 'https://www.minisail.cz/setkani/z-akci/id:11371/zamykani-terlicko-2019'
+			}
+		],
+		gallery: [
+			{
+				label: 'Drive-Seb',
+				url: 'https://drive.google.com/drive/folders/1Wn3iQHFyGFzaUUOAenkkFOkBhoHOTVun?usp=sharing'
+			},
+			{ label: 'Rajce-Ferodedek', url: 'https://minisail.rajce.idnes.cz/Terlicko_2019/' }
+		]
+	},
+	{
+		year: 2018,
+		results: { type: 'download' },
+		articles: [
+			{
+				label: 'minisail.cz',
+				url: 'https://www.minisail.cz/setkani/z-akci/id:10492/terlicka-plachta-2018'
+			}
+		],
+		gallery: [
+			{ label: 'Rajce-Kubik-team', url: 'https://kubik-team.rajce.idnes.cz/Terlicka_plachta_2018/' },
+			{
+				label: 'Rajce-Ferodedek',
+				url: 'https://minisail.rajce.idnes.cz/Terlicka_plachta_-_Terlicko_2018/?'
+			},
+			{ label: 'Rajce-MoNaKo', url: 'https://monako.rajce.idnes.cz/terlicko_nss_180928/' }
+		]
+	},
+	{
+		year: 2017,
+		results: { type: 'download' },
+		articles: [
+			{
+				label: 'modelyznojmo.webnode.cz',
+				url: 'https://modelyznojmo.webnode.cz/kde-jsme-byli/terlicka-plachta-30-9-2017/'
+			},
+			{ label: 'minisail.cz', url: 'https://www.minisail.cz/setkani/z-akci/id:9036/terlicko-2017' }
+		],
+		gallery: [
+			{
+				label: 'Rajce-modelyzn',
+				url: 'https://modelyzn.rajce.idnes.cz/Modely_Znojmo_Terlicka_plachta_30.9.2017/'
+			},
+			{ label: 'Youtube-Pavel Trvaj', url: 'https://www.youtube.com/watch?v=VjzVdAk6-Sw' },
+			{ label: 'RCportal.sk-guitar61', url: 'https://www.rcportal.sk/terlicka-plachta-2017-g4826' },
+			{ label: 'Youtube-Martin Machalík', url: 'https://www.youtube.com/watch?v=f2V4tbh1YcI' },
+			{ label: 'Rajce-Ferodedek', url: 'https://minisail.rajce.idnes.cz/Terlicko_2017/' },
+			{ label: 'Rajce-MoNaKo', url: 'https://monako.rajce.idnes.cz/terlicko_nss_machalik_170929/' }
+		]
+	},
+	{
+		year: 2016,
+		results: { type: 'download' },
+		articles: [
+			{
+				label: 'minisail.cz',
+				url: 'https://www.minisail.cz/setkani/z-akci/id:6783/zaver-sezony-terlicko-2016'
+			}
+		],
+		gallery: [
+			{ label: 'Rajce-Ferodedek', url: 'https://minisail.rajce.idnes.cz/Terlicko_2016/' },
+			{ label: 'Rajce-MoNaKo', url: 'https://monako.rajce.idnes.cz/terlicko_nss_160929/' },
+			{
+				label: 'Drive-Seb',
+				url: 'https://drive.google.com/drive/folders/1d_RC8fPRuFfclPdS7at1Q_6uMBAIiKaw?usp=share_link'
+			}
+		]
+	},
+	{
+		year: 2015,
+		results: { type: 'download' },
+		articles: [
+			{
+				label: 'minisail.cz',
+				url: 'https://www.minisail.cz/setkani/z-akci/id:4495/terlicko-zamykani-2015'
+			}
+		],
+		gallery: [
+			{ label: 'Rajce-Ferodedek', url: 'https://minisail.rajce.idnes.cz/Terlicko_2015/' },
+			{ label: 'Rajce-MoNaKo', url: 'https://monako.rajce.idnes.cz/terlicko_nss_150925/' },
+			{ label: 'Rajce-MoNaKo-2', url: 'https://monako.rajce.idnes.cz/terlicko_nss_150924/' }
+		]
+	},
+	{
+		year: 2014,
+		results: { type: 'download' },
+		articles: [],
+		gallery: [
+			{ label: 'daja-se.rajce.idnes.cz', url: 'https://daja-se.rajce.idnes.cz/Terlicka_plachta/' },
+			{ label: 'modelteam.com.pl', url: 'www.modelteam.com.pl/galeria/thumbnails.php?album=166' }
+		]
+	},
+	{
+		year: 2013,
+		results: { type: 'download' },
+		articles: [
+			{
+				label: 'minisail.cz',
+				url: 'https://www.minisail.cz/setkani/z-akci/id:2524/terlicko-2013-pozdni-setkani-'
+			}
+		],
+		gallery: [
+			{ label: 'Rajce-Ferodedek', url: 'https://minisail.rajce.idnes.cz/Terlicko_2013/' },
+			{ label: 'Rajce-MoNaKo', url: 'https://monako.rajce.idnes.cz/terlicko_nss_131011/' },
+			{ label: 'Rajce-MoNaKo-2', url: 'https://monako.rajce.idnes.cz/terlicko_nss_131013/' },
+			{ label: 'modelteam.com.pl', url: 'http://www.modelteam.com.pl/galeria/thumbnails.php?album=165' }
+		]
+	},
+	{
+		year: 2012,
+		results: { type: 'download' },
+		articles: [
+			{ label: 'minisail.cz', url: 'https://www.minisail.cz/setkani/z-akci/id:2481/terlicko-2012' }
+		],
+		gallery: [
+			{
+				label: 'moravskoslezsky.denik.cz',
+				url: 'https://moravskoslezsky.denik.cz/z-regionu/obrazem-soutez-radiem-rizenych-modelu-plachetnic-20120929.html'
+			},
+			{ label: 'terlicko.cz', url: 'http://terlicko.cz/terlicka-plachta-2012-09-28-30/gs-1062' },
+			{ label: 'Rajce-Ferodedek', url: 'https://minisail.rajce.idnes.cz/Terlicko_2012/' },
+			{ label: 'modelteam.com.pl', url: 'http://www.modelteam.com.pl/galeria/thumbnails.php?album=149' }
+		]
+	},
+	{
+		year: 2011,
+		results: { type: 'download' },
+		articles: [
+			{
+				label: 'minisail.cz',
+				url: 'https://www.minisail.cz/setkani/z-akci/id:2438/terlicko-zamykani-2011'
+			}
+		],
+		gallery: [
+			{ label: 'modelteam.com.pl', url: 'http://www.modelteam.com.pl/galeria/thumbnails.php?album=127' }
+		]
+	}
+];

--- a/web_new/src/routes/historie/+page.svelte
+++ b/web_new/src/routes/historie/+page.svelte
@@ -1,0 +1,318 @@
+<script>
+	import { historyData } from '$lib/data/history.js';
+
+	/** @type {Record<number, string | null>} */
+	let expandedSection = $state({});
+
+	/**
+	 * @param {number} year
+	 * @param {string} section
+	 */
+	function toggleSection(year, section) {
+		if (expandedSection[year] === section) {
+			expandedSection[year] = null;
+		} else {
+			expandedSection[year] = section;
+		}
+	}
+
+</script>
+
+<svelte:head>
+	<title>Historie | Těrlická plachta</title>
+</svelte:head>
+
+<div class="container">
+	<header class="page-header">
+		<h1>Historie</h1>
+		<p>Portské, buček, soudek rumu. A tak to všechno začalo...</p>
+	</header>
+
+	<nav class="year-nav">
+		<div class="nav-inner">
+			{#each historyData as data}
+				<a href="#{data.year}" class="year-link">{data.year}</a>
+			{/each}
+		</div>
+	</nav>
+
+	<div class="history-list">
+		{#each historyData as data}
+			<section id={String(data.year)} class="year-card">
+				<h2>{data.year}</h2>
+
+				<div class="gallery-placeholders">
+					<div class="main-images">
+						<div class="placeholder large">FOTKA 1 (100%)</div>
+						<div class="placeholder large">FOTKA 2 (100%)</div>
+					</div>
+					<div class="sub-images">
+						<div class="placeholder small">FOTKA 3</div>
+						<div class="placeholder small">FOTKA 4</div>
+						<div class="placeholder small">FOTKA 5</div>
+						<div class="placeholder small">FOTKA 6</div>
+					</div>
+				</div>
+
+				<div class="card-actions">
+					<button
+						class="action-btn"
+						class:active={expandedSection[data.year] === 'articles'}
+						onclick={() => toggleSection(data.year, 'articles')}
+					>
+						Články ↧
+					</button>
+					<button
+						class="action-btn"
+						class:active={expandedSection[data.year] === 'gallery'}
+						onclick={() => toggleSection(data.year, 'gallery')}
+					>
+						Galerie ↧
+					</button>
+					{#if data.results.type === 'download'}
+						<a
+							href="/vysledky/vysledky-{data.year}.xlsx"
+							download="vysledky-{data.year}.xlsx"
+							class="action-btn link-btn"
+						>
+							Výsledky ↧
+						</a>
+					{:else}
+						<a href={data.results.url} class="action-btn link-btn">
+							Výsledky ↧
+						</a>
+					{/if}
+				</div>
+
+				{#if expandedSection[data.year]}
+					<div class="expanded-content">
+						{#if expandedSection[data.year] === 'articles'}
+							<div class="links-list">
+								{#if data.articles.length > 0}
+									{#each data.articles as article}
+										<a href={article.url} target="_blank" rel="noopener noreferrer" class="external-link">
+											{article.label}
+										</a>
+									{/each}
+								{:else}
+									<p>Žádné články k dispozici.</p>
+								{/if}
+							</div>
+						{:else if expandedSection[data.year] === 'gallery'}
+							<div class="links-list">
+								{#if data.gallery.length > 0}
+									{#each data.gallery as item}
+										<a href={item.url} target="_blank" rel="noopener noreferrer" class="external-link">
+											{item.label}
+										</a>
+									{/each}
+								{:else}
+									<p>Žádné galerie k dispozici.</p>
+								{/if}
+							</div>
+						{/if}
+					</div>
+				{/if}
+			</section>
+		{/each}
+	</div>
+</div>
+
+<style>
+	.container {
+		max-width: 1180px;
+		margin: 0 auto;
+		padding: 0 20px 60px;
+	}
+
+	.page-header {
+		text-align: center;
+		margin-bottom: 40px;
+	}
+
+	h1 {
+		font-size: 3rem;
+		margin-bottom: 10px;
+	}
+
+	.year-nav {
+		margin: 30px 0;
+		position: relative;
+		text-align: center;
+	}
+
+	.year-nav::before {
+		content: '';
+		position: absolute;
+		top: 50%;
+		left: 0;
+		right: 0;
+		height: 1px;
+		background: rgba(255, 255, 255, 0.3);
+		z-index: 0;
+	}
+
+	.nav-inner {
+		position: relative;
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 15px;
+		z-index: 1;
+	}
+
+	.year-link {
+		background-color: #45cece;
+		color: #303b4a;
+		padding: 8px 16px;
+		border-radius: 5px;
+		font-weight: bold;
+		transition: all 0.2s;
+	}
+
+	.year-link:hover {
+		background-color: white;
+		color: #45cece;
+	}
+
+	.history-list {
+		display: flex;
+		flex-direction: column;
+		gap: 30px;
+	}
+
+	.year-card {
+		background-color: #dadfe4;
+		border-radius: 8px;
+		padding: 25px;
+		color: #303b4a;
+		scroll-margin-top: 20px;
+	}
+
+	.year-card h2 {
+		margin-top: 0;
+		font-size: 2rem;
+		border-bottom: 2px solid #303b4a;
+		display: inline-block;
+		margin-bottom: 20px;
+	}
+
+	.gallery-placeholders {
+		display: flex;
+		flex-direction: column;
+		gap: 15px;
+		margin-bottom: 20px;
+	}
+
+	.main-images {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 15px;
+	}
+
+	.sub-images {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 15px;
+	}
+
+	.placeholder {
+		background-color: #bdc3c7;
+		border: 2px dashed #7f8c8d;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: #7f8c8d;
+		font-weight: bold;
+		border-radius: 4px;
+	}
+
+	.placeholder.large {
+		aspect-ratio: 16 / 9;
+	}
+
+	.placeholder.small {
+		aspect-ratio: 4 / 3;
+	}
+
+	.card-actions {
+		display: flex;
+		justify-content: space-around;
+		gap: 15px;
+		margin-top: 20px;
+	}
+
+	.action-btn {
+		flex: 1;
+		background-color: #303b4a;
+		color: white;
+		border: none;
+		border-radius: 4px;
+		padding: 10px;
+		cursor: pointer;
+		font-size: 1rem;
+		transition: all 0.2s;
+	}
+
+	.action-btn:hover {
+		background-color: white;
+		color: #303b4a;
+		outline: 2px solid #303b4a;
+		text-decoration: none;
+	}
+
+	.link-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		text-decoration: none;
+	}
+
+	.action-btn.active {
+		background-color: white;
+		color: #303b4a;
+	}
+
+	.expanded-content {
+		margin-top: 20px;
+		padding-top: 20px;
+		border-top: 1px solid rgba(48, 59, 74, 0.2);
+	}
+
+	.links-list {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 10px;
+	}
+
+	.external-link {
+		background-color: #303b4a;
+		color: white;
+		padding: 8px 20px;
+		border-radius: 4px;
+		text-decoration: none;
+		min-width: 200px;
+		text-align: center;
+		transition: all 0.2s;
+	}
+
+	.external-link:hover {
+		background-color: #45cece;
+	}
+
+	@media (max-width: 800px) {
+		.main-images {
+			grid-template-columns: 1fr;
+		}
+		.sub-images {
+			grid-template-columns: 1fr 1fr;
+		}
+		.card-actions {
+			flex-direction: column;
+		}
+		.action-btn {
+			width: 100%;
+		}
+	}
+</style>


### PR DESCRIPTION
I have migrated the historical content from the legacy website to the new `web_new` project.

Key changes:
1.  **Data Migration**: Created `web_new/src/lib/data/history.js` containing all metadata for years 2011–2025, including links to articles, galleries, and results.
2.  **History Page**: Created a new Svelte component at `web_new/src/routes/historie/+page.svelte` that:
    - Features a sticky-ish year navigation menu.
    - Displays each year as a card with image placeholders (2 large, 4 small).
    - Includes interactive "Articles" and "Gallery" buttons that expand to show lists of external/internal links.
    - Handles results via direct XLSX downloads or external viewer links.
3.  **Navigation**: Updated `web_new/src/lib/components/Navbar.svelte` to link to the new page and correctly highlight it when active.
4.  **Verification**: Verified the layout and interactivity using Playwright screenshots and ensured the build passes with `npm run check`.

Placeholders were used for images as requested, allowing for manual image migration later.

---
*PR created automatically by Jules for task [2942700317785414339](https://jules.google.com/task/2942700317785414339) started by @Thechopsee*