### PR TITLE
Remove Výsledky from menu and update history link

### DIFF
--- a/web_new/src/lib/components/Navbar.svelte
+++ b/web_new/src/lib/components/Navbar.svelte
@@ -15,8 +15,6 @@
 		<span class="sep">|</span>
 		<a href="/historie" class:active={page.url.pathname.startsWith('/historie')}>Historie</a>
 		<span class="sep">|</span>
-		<a href="/vysledky" class:active={page.url.pathname === '/vysledky'}>Výsledky</a>
-		<span class="sep">|</span>
 		<a href="/registrace" class:active={page.url.pathname === '/registrace'}>Registrace</a>
 		<span class="sep">|</span>
 		<a href="/kontakty" class:active={page.url.pathname === '/kontakty'}>Kontakt</a>
@@ -24,7 +22,6 @@
 	<nav id="menu_mob">
 		<a href="/" class:active={page.url.pathname === '/'}>Těrlická plachta 2026</a>
 		<a href="/historie" class:active={page.url.pathname.startsWith('/historie')}>Historie</a>
-		<a href="/vysledky" class:active={page.url.pathname === '/vysledky'}>Výsledky</a>
 		<a href="/registrace" class:active={page.url.pathname === '/registrace'}>Registrace</a>
 		<a href="/kontakty" class:active={page.url.pathname === '/kontakty'}>Kontakt</a>
 	</nav>

--- a/web_new/src/lib/data/history.js
+++ b/web_new/src/lib/data/history.js
@@ -75,7 +75,7 @@ export const historyData = [
 	},
 	{
 		year: 2022,
-		results: { type: 'link', url: '/vysledky.html' },
+		results: { type: 'link', url: '/vysledky' },
 		articles: [
 			{
 				label: 'Minisail.cz',


### PR DESCRIPTION
I have removed the "Výsledky" (Results) link from the navigation menu in the new web project, as requested. The results are now exclusively accessible from the "Historie" page. Additionally, I updated the link for the 2022 results to correctly point to the internal route within the application.

Changes:
- Modified `web_new/src/lib/components/Navbar.svelte` to remove the "Výsledky" link.
- Updated `web_new/src/lib/data/history.js` to change the 2022 results URL from `/vysledky.html` to `/vysledky`.

---
*PR created automatically by Jules for task [3794728973526015864](https://jules.google.com/task/3794728973526015864) started by @Thechopsee*