### PR TITLE
Improve homepage card text readability

### DIFF
--- a/web_new/src/routes/+page.svelte
+++ b/web_new/src/routes/+page.svelte
@@ -80,6 +80,10 @@
 		color: #dadfe4;
 	}
 
+	.info-card p {
+		color: #303b4a;
+	}
+
 	.propozice-section {
 		margin-bottom: 60px;
 	}
@@ -115,13 +119,14 @@
 		letter-spacing: 0.18em;
 		font-size: 0.7rem;
 		font-weight: 600;
-		color: #45cece;
+		color: #008080;
 	}
 
 	.status {
 		margin-bottom: 30px;
 		font-style: italic;
-		opacity: 0.8;
+		opacity: 1;
+		color: #303b4a;
 	}
 
 	#propozice {


### PR DESCRIPTION
This change improves the readability of the informational cards (Kdy, Kde, Co, Propozice) on the homepage. The previous light gray and light teal colors had insufficient contrast against the semi-transparent white background of the cards.

Changes:
- Added a specific CSS rule for `.info-card p` to use a dark slate color (`#303b4a`).
- Updated `.eyebrow-header` to use a darker teal (`#008080`).
- Updated `.status` to be fully opaque and use the dark slate color.

Verification:
- Visual verification performed via Playwright screenshots.
- `npm run check` passed successfully.
- Code reviewed and temporary build/log files removed.

---
*PR created automatically by Jules for task [550053250899905191](https://jules.google.com/task/550053250899905191) started by @Thechopsee*