### PR TITLE
Preserve exdataterms.html across builds

### DIFF
--- a/static/slezskoapps/exdataterms.html
+++ b/static/slezskoapps/exdataterms.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EX-Boat DC – Zásady ochrany soukromí / Privacy Policy</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            max-width: 800px;
+            margin: auto;
+            padding: 20px;
+            color: #333;
+        }
+        h1, h2 {
+            margin-top: 1.5em;
+        }
+        hr {
+            margin: 40px 0;
+        }
+    </style>
+</head>
+<body>
+
+<h1>Zásady ochrany soukromí</h1>
+
+<h2>Úvod</h2>
+<p>Tyto zásady ochrany soukromí se vztahují na aplikaci <strong>EX-Boat DC</strong> (dále jen „aplikace“), kterou vyvíjí a provozuje <strong>Sebastián Walenta</strong>.</p>
+<p>Aplikace respektuje soukromí uživatelů a je navržena tak, aby nevyžadovala ani nezpracovávala osobní údaje.</p>
+
+<h2>Shromažďování a používání údajů</h2>
+<p>Aplikace neshromažďuje žádné osobní údaje uživatelů, jako jsou jména, e-mailové adresy nebo jiné identifikátory.</p>
+<p>Veškerá data používaná aplikací se týkají výhradně výsledků lodních soutěží. Tato data nejsou nijak spojena s konkrétní fyzickou osobou, ale pouze s loděmi.</p>
+
+<h2>Uživatelské účty</h2>
+<p>Aplikace nevyžaduje registraci ani vytvoření uživatelského účtu.</p>
+
+<h2>Synchronizace dat</h2>
+<p>Aplikace může synchronizovat data s externími uzly (servery), které si uživatelé provozují sami nebo ve skupině. Tato komunikace slouží pouze k přenosu technických a soutěžních dat a neobsahuje osobní údaje.</p>
+
+<h2>Sdílení dat</h2>
+<p>Aplikace nesdílí žádná data třetím stranám.</p>
+
+<h2>Zabezpečení</h2>
+<p>I přesto, že aplikace nezpracovává osobní údaje, jsou přijímána přiměřená opatření k zajištění bezpečného přenosu dat mezi zařízeními a servery.</p>
+
+<h2>Změny zásad</h2>
+<p>Tyto zásady ochrany soukromí mohou být v budoucnu aktualizovány. Aktuální verze bude vždy dostupná na této stránce.</p>
+
+<h2>Kontakt</h2>
+<p>Vývojář a provozovatel aplikace: <strong>Sebastián Walenta</strong></p>
+<p>E-mail: <a href="mailto:sebastian.walent@gmail.com">sebastian.walent@gmail.com</a></p>
+
+<hr>
+
+<h1>Privacy Policy</h1>
+
+<h2>Introduction</h2>
+<p>This Privacy Policy applies to the <strong>EX-Boat DC</strong> application (the “Application”), developed and operated by <strong>Sebastián Walenta</strong>.</p>
+<p>The Application respects user privacy and is designed not to collect or process any personal data.</p>
+
+<h2>Data Collection and Use</h2>
+<p>The Application does not collect any personal data such as names, email addresses, or other personal identifiers.</p>
+<p>All data used within the Application relates exclusively to sailing competition results. These data are not linked to any individual person, but only to boats.</p>
+
+<h2>User Accounts</h2>
+<p>The Application does not require user registration or the creation of user accounts.</p>
+
+<h2>Data Synchronization</h2>
+<p>The Application may synchronize data with external nodes (servers), which are operated by users individually or within a group. This communication is used solely for transferring technical and competition-related data and does not include personal data.</p>
+
+<h2>Data Sharing</h2>
+<p>The Application does not share any data with third parties.</p>
+
+<h2>Security</h2>
+<p>Even though the Application does not process personal data, reasonable measures are taken to ensure secure data transmission between devices and servers.</p>
+
+<h2>Changes to This Policy</h2>
+<p>This Privacy Policy may be updated in the future. The current version will always be available on this page.</p>
+
+<h2>Contact</h2>
+<p>Developer and operator of the Application: <strong>Sebastián Walenta</strong></p>
+<p>Email: <a href="mailto:sebastian.walent@gmail.com">sebastian.walent@gmail.com</a></p>
+
+</body>
+</html>


### PR DESCRIPTION
I have added the `exdataterms.html` file to the `static/slezskoapps/` directory. This ensures that the file is included in the SvelteKit build output (`build/slezskoapps/exdataterms.html`) and subsequently deployed to the `gh-pages` branch by the existing deployment script. This solves the issue where the file had to be manually added to the `gh-pages` branch after each build.

---
*PR created automatically by Jules for task [14133057259727229386](https://jules.google.com/task/14133057259727229386) started by @Thechopsee*